### PR TITLE
docs: 7th patch missing

### DIFF
--- a/docs/patches/upstream-status.md
+++ b/docs/patches/upstream-status.md
@@ -31,6 +31,7 @@ Progress toward getting these fixes into the mainline Linux kernel.
 4. `wifi: mt76: mt7925: add MCU command error handling in ampdu_action`
 5. `wifi: mt76: mt7925: add lockdep assertions for mutex verification`
 6. `wifi: mt76: mt7925: fix MLO ROC setup error handling`
+7. `wifi: mt76: mt7925: add error logging for MLO ROC setup in set_links`
 
 ### v6 (January 2026)
 

--- a/docs/patches/upstream-status.md
+++ b/docs/patches/upstream-status.md
@@ -12,6 +12,7 @@ Progress toward getting these fixes into the mainline Linux kernel.
 | 04 - MCU error handling | :material-email:{ .yellow } Submitted | v7 series |
 | 05 - Lockdep assertions | :material-email:{ .yellow } Submitted | v7 series |
 | 06 - MLO ROC error handling | :material-email:{ .yellow } Submitted | v7 series |
+| 07 - MLO ROC error logging  | :material-email:{ .yellow } Submitted | v7 series |
 
 ## Submission History
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the upstream status documentation to include the missing mt7925 MLO ROC error logging patch in the v6 series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new v7 patch entry tracking error logging improvements for Wi‑Fi MLO ROC setup.
  * Updated the Current Status table to include the new patch as Submitted.
  * Updated the v7 Submission History to list the new patch under the January 29, 2026 snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->