### PR TITLE
Kernel 7.x support: build regex, ieee80211_mgmt compat, installer set -e fix

### DIFF
--- a/dkms/dkms.conf
+++ b/dkms/dkms.conf
@@ -9,7 +9,7 @@ PACKAGE_VERSION="1.5.0"
 AUTOINSTALL="yes"
 
 # Only build on kernel 6.17+ (uses APIs not available in older kernels)
-BUILD_EXCLUSIVE_KERNEL="^6\.(1[7-9]|[2-9][0-9]).*"
+BUILD_EXCLUSIVE_KERNEL="^(6\.(1[7-9]|[2-9][0-9])|[7-9]\.).*"
 
 # Build configuration
 # Detect clang-built kernels and use LLVM toolchain

--- a/dkms/dkms.conf
+++ b/dkms/dkms.conf
@@ -9,7 +9,7 @@ PACKAGE_VERSION="1.5.0"
 AUTOINSTALL="yes"
 
 # Only build on kernel 6.17+ (uses APIs not available in older kernels)
-BUILD_EXCLUSIVE_KERNEL="^(6\.(1[7-9]|[2-9][0-9])|[7-9]\.).*"
+BUILD_EXCLUSIVE_KERNEL="^(6\.(1[7-9]|[2-9][0-9])|([7-9]|[1-9][0-9]+)\.).*"
 
 # Build configuration
 # Detect clang-built kernels and use LLVM toolchain

--- a/dkms/install.sh
+++ b/dkms/install.sh
@@ -46,7 +46,7 @@ check_telemetry_enabled() {
 # 2=unset), which aborts the script under set -e if called bare. Capture with
 # `status=$(telemetry_status)` instead of checking $? directly.
 telemetry_status() {
-    check_telemetry_enabled && echo 0 || echo $?
+    check_telemetry_enabled && echo 0 || echo "$?"
 }
 
 # Save telemetry preference

--- a/dkms/install.sh
+++ b/dkms/install.sh
@@ -42,6 +42,13 @@ check_telemetry_enabled() {
     return 2
 }
 
+# set -e-safe wrapper: check_telemetry_enabled signals via exit code (1=disabled,
+# 2=unset), which aborts the script under set -e if called bare. Capture with
+# `status=$(telemetry_status)` instead of checking $? directly.
+telemetry_status() {
+    check_telemetry_enabled && echo 0 || echo $?
+}
+
 # Save telemetry preference
 save_telemetry_preference() {
     echo "$1" > "$TELEMETRY_CONFIG" 2>/dev/null || true
@@ -133,8 +140,8 @@ send_queued_telemetry() {
     [[ ! -f "$TELEMETRY_QUEUE" ]] && return 0
 
     # Check if telemetry is enabled before sending queued events
-    check_telemetry_enabled
-    local status=$?
+    local status
+    status=$(telemetry_status)
     [[ $status -ne 0 ]] && return 0
 
     # Process each queued event
@@ -229,8 +236,8 @@ send_telemetry() {
     local wait_for_net="${3:-false}"
 
     # Check if telemetry is enabled
-    check_telemetry_enabled
-    local status=$?
+    local status
+    status=$(telemetry_status)
     if [[ $status -eq 1 ]]; then
         return 0  # Explicitly disabled
     elif [[ $status -eq 2 ]]; then

--- a/dkms/src/compat.h
+++ b/dkms/src/compat.h
@@ -41,6 +41,20 @@
 #define MT76_HAS_CSA_SUPPORT 1
 
 /*
+ * struct ieee80211_mgmt action-frame layout
+ * - 7.0 flattened the nested action union: u.action.u.addba_req became
+ *   u.action.addba_req, and action_code is read via u.action.action_code
+ * - 6.x keeps the nested form u.action.u.addba_req.{action_code,capab}
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+#define MT76_MGMT_ACTION_CODE(mgmt) ((mgmt)->u.action.action_code)
+#define MT76_MGMT_ADDBA_REQ(mgmt)   ((mgmt)->u.action.addba_req)
+#else
+#define MT76_MGMT_ACTION_CODE(mgmt) ((mgmt)->u.action.u.addba_req.action_code)
+#define MT76_MGMT_ADDBA_REQ(mgmt)   ((mgmt)->u.action.u.addba_req)
+#endif
+
+/*
  * ieee80211_iterate_active_interfaces() callback signature
  * Stable across 6.8-6.19+
  */

--- a/dkms/src/compat.h
+++ b/dkms/src/compat.h
@@ -42,11 +42,11 @@
 
 /*
  * struct ieee80211_mgmt action-frame layout
- * - 7.0 flattened the nested action union: u.action.u.addba_req became
+ * - 7.1 flattened the nested action union: u.action.u.addba_req became
  *   u.action.addba_req, and action_code is read via u.action.action_code
- * - 6.x keeps the nested form u.action.u.addba_req.{action_code,capab}
+ * - 7.0 and earlier keep the nested form u.action.u.addba_req.{action_code,capab}
  */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
 #define MT76_MGMT_ACTION_CODE(mgmt) ((mgmt)->u.action.action_code)
 #define MT76_MGMT_ADDBA_REQ(mgmt)   ((mgmt)->u.action.addba_req)
 #else

--- a/dkms/src/mt76_connac_mac.c
+++ b/dkms/src/mt76_connac_mac.c
@@ -412,8 +412,8 @@ mt76_connac2_mac_write_txwi_80211(struct mt76_dev *dev, __le32 *txwi,
 
 	if (ieee80211_is_action(fc) &&
 	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
-	    mgmt->u.action.u.addba_req.action_code == WLAN_ACTION_ADDBA_REQ) {
-		u16 capab = le16_to_cpu(mgmt->u.action.u.addba_req.capab);
+	    MT76_MGMT_ACTION_CODE(mgmt) == WLAN_ACTION_ADDBA_REQ) {
+		u16 capab = le16_to_cpu(MT76_MGMT_ADDBA_REQ(mgmt).capab);
 
 		txwi[5] |= cpu_to_le32(MT_TXD5_ADD_BA);
 		tid = (capab >> 2) & IEEE80211_QOS_CTL_TID_MASK;

--- a/dkms/src/mt7925/mac.c
+++ b/dkms/src/mt7925/mac.c
@@ -668,7 +668,7 @@ mt7925_mac_write_txwi_80211(struct mt76_dev *dev, __le32 *txwi,
 
 	if (ieee80211_is_action(fc) &&
 	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
-	    mgmt->u.action.u.addba_req.action_code == WLAN_ACTION_ADDBA_REQ)
+	    MT76_MGMT_ACTION_CODE(mgmt) == WLAN_ACTION_ADDBA_REQ)
 		tid = MT_TX_ADDBA;
 	else if (ieee80211_is_mgmt(hdr->frame_control))
 		tid = MT_TX_NORMAL;

--- a/dkms/src/mt7996/mac.c
+++ b/dkms/src/mt7996/mac.c
@@ -800,7 +800,7 @@ mt7996_mac_write_txwi_80211(struct mt7996_dev *dev, __le32 *txwi,
 
 	if (ieee80211_is_action(fc) &&
 	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
-	    mgmt->u.action.u.addba_req.action_code == WLAN_ACTION_ADDBA_REQ) {
+	    MT76_MGMT_ACTION_CODE(mgmt) == WLAN_ACTION_ADDBA_REQ) {
 		if (is_mt7990(&dev->mt76))
 			txwi[6] |= cpu_to_le32(FIELD_PREP(MT_TXD6_TID_ADDBA, tid));
 		else


### PR DESCRIPTION
Fedora 44 ships kernel 7.1.x, where the DKMS package currently doesn't build or install. Three small fixes:

1. **dkms.conf**: `BUILD_EXCLUSIVE_KERNEL` stopped at 6.x, so DKMS silently skipped the module on 7.x kernels. Widened to accept 7.x+.

2. **ieee80211_mgmt compat**: kernel 7.0 flattened the nested action-frame union (`u.action.u.addba_req` → `u.action.addba_req`, with `action_code` read via `u.action.action_code`). Added `MT76_MGMT_ACTION_CODE()` / `MT76_MGMT_ADDBA_REQ()` macros to the existing `compat.h` and used them at the three ADDBA txwi sites, so the same source builds on 6.17+ and 7.x.

3. **install.sh**: `check_telemetry_enabled` returns its result via exit code (1=disabled, 2=unset), which aborts the whole script under `set -e` when called bare — with `MT7925_TELEMETRY=0` the installer died mid-run after unloading the running driver, leaving the machine without Wi-Fi. Wrapped it in `telemetry_status()` so callers capture the code safely.

4. **EML_CAP delay-mask rename (7.2)**: kernel 7.2 ([torvalds/linux@5858f5e](https://github.com/torvalds/linux/commit/5858f5e1588fab66573d50c06dbcdd12830044ca)) renamed `IEEE80211_EML_CAP_EMLSR_{PADDING,TRANSITION}_DELAY` to `IEEE80211_EML_CAP_EML_*` (same values, now shared with EMLMR). `mt7925/mcu.c` uses the new names; `compat.h` aliases them when the headers only have the old ones (keyed on `#ifndef` rather than a version check so backports still build).

Tested on Fedora 44 (kernels 7.1.3 and 7.1.4, GCC-built, Secure Boot with DKMS MOK signing) on a Framework 16 with an MT7925 card: full DKMS build/sign/install cycle works, module loads and associates on a 3-link MLO AP. Fix 4 additionally build-tested against 7.2.4-200.fc44 and 7.1.13-200.fc44 headers.

Possibly worth a separate issue: the installer unloads the running driver before verifying the signed module can actually load (Secure Boot + unenrolled MOK → `modprobe` fails with "Key was rejected by service" and the script exits, leaving no Wi-Fi). Checking `mokutil --sb-state`/enrollment before `unload_modules` would avoid that.

## Summary by Sourcery

Ensure the DKMS driver builds on Linux 7.x and the installer safely completes when telemetry is disabled or unset.

Bug Fixes:
- Prevent the installer from aborting under `set -e` when telemetry is disabled or unset.
- Support building and installing the DKMS module on Linux 7.x kernels.

Enhancements:
- Add compatibility handling for kernel 7.x management-frame layout and renamed EML capability definitions across supported kernel versions.

Build:
- Extend DKMS kernel eligibility to include Linux 7.x and later kernels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Compatibility**
  - Extended DKMS support to Linux kernel versions 6.17 and newer, including 7.x and later releases.
  - Improved wireless driver compatibility with updated management-frame layouts and EML capability definitions in newer kernels.

- **Bug Fixes**
  - Improved handling of wireless Block Acknowledgment requests across supported chipsets.
  - Prevented telemetry checks during installation from causing unexpected script termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
